### PR TITLE
Alchohol units for men

### DIFF
--- a/lib/Telegram/Bot/AlcoholUnits.pm
+++ b/lib/Telegram/Bot/AlcoholUnits.pm
@@ -213,9 +213,8 @@ sub __report {
 	    $weeklyUnits, $days, $totalDrinks);
 
 	my $gender = $self->dic->genderClient->get($username);
-	my $their = $gender->their();
 	$totalDrinks++ if ($totalDrinks == 0); # Ensure no division by zero
-	$report .= "\n" . sprintf('%s average drink contained %.2f units.', $their, $weeklyUnits / $totalDrinks);
+	$report .= "\n" . sprintf('%s average drink contained %.2f units.', $gender->their(), $weeklyUnits / $totalDrinks);
 
 	$report .= sprintf("\nThat's %.2f units a day", $weeklyUnits / $days);
 	$report .= __govWarning($weeklyUnits, $gender);

--- a/lib/Telegram/Bot/AlcoholUnits.pm
+++ b/lib/Telegram/Bot/AlcoholUnits.pm
@@ -39,8 +39,9 @@ use Readonly;
 use Scalar::Util qw(looks_like_number);
 use Telegram::Bot::DrinkInfo;
 
-Readonly my $MAX_MEN   => 21;
-Readonly my $MAX_WOMEN => 14;
+Readonly my $MAX_MEN     => 21;
+Readonly my $MAX_WOMEN   => 14;
+Readonly my $MAX_DEFAULT => $MAX_WOMEN;
 
 Readonly my $BOTTLE         => 750;
 Readonly my $CAN_L          => 440;
@@ -211,19 +212,22 @@ sub __report {
 	$report .= sprintf('%s drank %.1f units in the past %d days, over %d separate drinks...', $username,
 	    $weeklyUnits, $days, $totalDrinks);
 
-	my $their = $self->dic->genderClient->get($username)->their();
+	my $gender = $self->dic->genderClient->get($username);
+	my $their = $gender->their();
 	$totalDrinks++ if ($totalDrinks == 0); # Ensure no division by zero
 	$report .= "\n" . sprintf('%s average drink contained %.2f units.', $their, $weeklyUnits / $totalDrinks);
 
 	$report .= sprintf("\nThat's %.2f units a day", $weeklyUnits / $days);
-	$report .= __govWarning($weeklyUnits);
+	$report .= __govWarning($weeklyUnits, $gender);
 
 	return $report;
 }
 
 sub __govWarning {
-	my ($weeklyUnits) = @_;
-	return '' if ($weeklyUnits < $MAX_WOMEN);
+	my ($weeklyUnits, $gender) = @_;
+
+	my $max = $gender->value eq 'male' ? $MAX_MEN : $MAX_DEFAULT;
+	return '' if ($weeklyUnits < $max);
 
 	my $message = sprintf("\nWARNING: The UK guidelines (1995) advise against regularly imbibing more than %d units a week for men and %d for women.",
 	    $MAX_MEN, $MAX_WOMEN);

--- a/lib/Telegram/Bot/AlcoholUnits.pm
+++ b/lib/Telegram/Bot/AlcoholUnits.pm
@@ -39,6 +39,9 @@ use Readonly;
 use Scalar::Util qw(looks_like_number);
 use Telegram::Bot::DrinkInfo;
 
+Readonly my $MAX_MEN   => 21;
+Readonly my $MAX_WOMEN => 14;
+
 Readonly my $BOTTLE         => 750;
 Readonly my $CAN_L          => 440;
 Readonly my $CAN_S          => 330;
@@ -220,9 +223,10 @@ sub __report {
 
 sub __govWarning {
 	my ($weeklyUnits) = @_;
-	return '' if ($weeklyUnits <= 14);
+	return '' if ($weeklyUnits < $MAX_WOMEN);
 
-	my $message = "\nWARNING: The UK CMO advises against regularly imbibing more than 14 units in a week.";
+	my $message = sprintf("\nWARNING: The UK guidelines (1995) advise against regularly imbibing more than %d units a week for men and %d for women.",
+	    $MAX_MEN, $MAX_WOMEN);
 	$message .= "\nThe CMO advises over 50 units a week is high risk drinking." if ($weeklyUnits > 50);
 	return $message;
 }


### PR DESCRIPTION
Change the alcohol units for men to 1995 levels (21).
After reading an article in The Spectator by [Christopher Snowdon](https://www.spectator.co.uk/writer/christopher-snowdon/)

According to this [article](https://www.spectator.co.uk/article/the-great-alcohol-cover-up-how-public-health-hid-the-truth-about-drinking), the latest (2016) guidelines are at least partially based on assuming people will drink more than the guidelines.